### PR TITLE
build: TSファイルのビルドをnpm scriptで行う

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,9 +8,8 @@ bluescripture
 # Common node modules locations
 /node_modules
 
-# JS files built during development
-asset/js/*
-src/*.js
+# JS files created by tsc
+asset/js/*.js
 
 # Location of files for which YoStar has rights
 asset/images/background

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,8 +12,7 @@
 - リポジトリをcloneする
 - TypeScriptをトランスパイルする
     1. リポジトリのルートで`npm install`を実行して必要なモジュールをインストールする
-    2. `npx tsc`を実行してTypeScriptファイルをトランスパイルする
-    3. `asset/js`フォルダを作成し、生成されたJavaScriptファイルを移動する
+    2. `npm run build`を実行してTypeScriptファイルをトランスパイルする
 - バックエンドを起動する
 bluescripture.goの実行方法の例を以下に示します。
     - IDEのデバッグ機能を使う(オススメ)

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "![BlueScripture_Header](https://user-images.githubusercontent.com/64777517/199688177-b20cb4b9-b8c4-4489-aca2-87648e91e558.png)\r Blue ScriptureはYostarによるスマートフォン向けゲーム「[ブルーアーカイブ（ブルアカ）](https://bluearchive.jp)」の情報を集積・発信しているファンサイトです。",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "build": "tsc --outDir ./asset/js"
   },
   "repository": {
     "type": "git",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -99,5 +99,8 @@
     /* Completeness */
     // "skipDefaultLibCheck": true,                      /* Skip type checking .d.ts files that are included with TypeScript. */
     "skipLibCheck": true                                 /* Skip type checking all .d.ts files. */
-  }
+  },
+  "include": [
+    "src/**/*"
+  ],
 }


### PR DESCRIPTION
## ねらい

- 変更ごとに発生するファイルを移動させる手間の削減
- より一般的なビルド手法を使用して学習コストを下げる

## その他の変更

- asset/jsに.gitkeepを追加して空フォルダを維持する
  - それに伴う.gitignoreの変更
- ビルド方法の変更に伴うCONTRIBUTING.mdの変更
- ビルドファイルを明確にするためにtsconfigにincludeを追記